### PR TITLE
Updated README.md to add link to agate-lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lookup
 
-A repository of journalist's lookup tables. Designed for programmatic access using tools such as [agate-lookup](TKTK).
+A repository of journalist's lookup tables. Designed for programmatic access using tools such as [agate-lookup](https://github.com/wireservice/agate-lookup).
 
 Anyone may contribute a lookup table by sending a pull request to this repository.
 


### PR DESCRIPTION
Changed TKTK link to link to the `agate-lookup` Github repo.

P.S. This is really cool! Only noticed that placeholder when I was reading up on agate and thinking about how it could fit in with my current workflows.
