### PR TITLE
Adding county FIPS table for US & territories

### DIFF
--- a/fips/county.csv.yml
+++ b/fips/county.csv.yml
@@ -1,0 +1,20 @@
+data: County FIPS codes and US county/state names
+version: N/A
+sources:
+  - United States Census Bureau, http://www.census.gov/geo/reference/ansi_statetables.html
+contributors:
+  - Christopher Groskopf <chrisgroskopf@gmail.com>
+  - Aaron Weiss <aaronwe@gmail.com>
+columns:
+  admin_fips:
+    name: County FIPS code
+    type: Text
+  county_name:
+    name: County name
+    type: Text
+  state_usps:
+    name: USPS state abbreviation
+    type: Text
+  state_long:
+    name: State name
+    type: Text


### PR DESCRIPTION
Hello! I added a FIPS table with all US counties and territories. It's got two state columns, the full name and the postal code. If it's better with just one, I'm happy to nuke whichever you think is less useful.

If this table is too big to be useful (it's 8 MB), we could split it into tables for each state, although my inclination is to keep it all together and let users filter it as they need.
